### PR TITLE
Sdkdev 94 add global prop

### DIFF
--- a/android/src/main/java/com/singular/flutter_sdk/SingularSDK.java
+++ b/android/src/main/java/com/singular/flutter_sdk/SingularSDK.java
@@ -228,7 +228,6 @@ public class SingularSDK implements FlutterPlugin, ActivityAware, MethodCallHand
         }
       }
     } catch (Exception e){
-      e.printStackTrace();
     }
 
 

--- a/android/src/main/java/com/singular/flutter_sdk/SingularSDK.java
+++ b/android/src/main/java/com/singular/flutter_sdk/SingularSDK.java
@@ -217,14 +217,21 @@ public class SingularSDK implements FlutterPlugin, ActivityAware, MethodCallHand
       singularConfig.withIMEI(imei);
     }
 
-    ArrayList<Map>  globalProps =  (ArrayList<Map>)configDict.get("globalProperties");
-
-    for (Map prop: globalProps){
-      String key = (String)prop.get("key");
-      String value = (String)prop.get("value");
-      boolean overrideExisting = (boolean)prop.get("overrideExisting");
-      singularConfig.withGlobalProperty(key, value, overrideExisting);
+    try{
+      ArrayList<Map>  globalProps =  (ArrayList<Map>)configDict.get("globalProperties");
+      if (globalProps != null){
+        for (Map prop: globalProps){
+          String key = (String)prop.get("key");
+          String value = (String)prop.get("value");
+          boolean overrideExisting = (boolean)prop.get("overrideExisting");
+          singularConfig.withGlobalProperty(key, value, overrideExisting);
+        }
+      }
+    } catch (Exception e){
+      e.printStackTrace();
     }
+
+
 
     singularLinkHandler = new SingularLinkHandler() {
       @Override

--- a/android/src/main/java/com/singular/flutter_sdk/SingularSDK.java
+++ b/android/src/main/java/com/singular/flutter_sdk/SingularSDK.java
@@ -25,6 +25,7 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
 import android.util.Log;
+import java.util.ArrayList;
 
 
 /** FlutterSdkPlugin */
@@ -214,6 +215,15 @@ public class SingularSDK implements FlutterPlugin, ActivityAware, MethodCallHand
     String imei = (String) configDict.get("imei");
     if (imei != null) {
       singularConfig.withIMEI(imei);
+    }
+
+    ArrayList<Map>  globalProps =  (ArrayList<Map>)configDict.get("globalProperties");
+
+    for (Map prop: globalProps){
+      String key = (String)prop.get("key");
+      String value = (String)prop.get("value");
+      boolean overrideExisting = (boolean)prop.get("overrideExisting");
+      singularConfig.withGlobalProperty(key, value, overrideExisting);
     }
 
     singularLinkHandler = new SingularLinkHandler() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -107,6 +107,9 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
       deeplinkParams['passthrough'] = params.passthrough;
       deeplinkParams['isDeferred'] = params.isDeferred;
     };
+
+    config.withGlobalProperty("key1", "value1", true);
+    config.withGlobalProperty("key2", "value2", true);
     
     config.conversionValueUpdatedCallback = (int conversionValue) {
       print('Received conversionValueUpdatedCallback: ' +

--- a/ios/Classes/SingularSDK.m
+++ b/ios/Classes/SingularSDK.m
@@ -104,11 +104,13 @@ static NSDictionary *configDict;
     config.shortLinkResolveTimeOut = shortLinkResolveTimeOut;
     NSArray *props = configDict[@"globalProperties"];
 
-    for (NSDictionary *prop in props) {
-        NSString *key = [prop objectForKey:@"key"];
-        NSString *value = [prop objectForKey:@"value"];
-        BOOL overrideExisting = [[prop objectForKey:@"overrideExisting"]boolValue];
-        [config setGlobalProperty:key withValue:value overrideExisting:overrideExisting];
+    if (props != nil) {
+        for (NSDictionary *prop in props) {
+            NSString *key = [prop objectForKey:@"key"];
+            NSString *value = [prop objectForKey:@"value"];
+            BOOL overrideExisting = [[prop objectForKey:@"overrideExisting"]boolValue];
+            [config setGlobalProperty:key withValue:value overrideExisting:overrideExisting];
+        }
     }
 
     if (customUserId) {

--- a/lib/singular_config.dart
+++ b/lib/singular_config.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/services.dart';
+import 'dart:collection';
 import 'package:singular_flutter_sdk/singular_link_params.dart';
+import 'package:singular_flutter_sdk/singular_global_property.dart';
+
 
 typedef void SingularLinksHandler(SingularLinkParams params);
 typedef void ConversionValueUpdatedCallback(int conversionValue);
@@ -27,6 +30,7 @@ class SingularConfig {
   bool collectOAID = false;
   bool enableLogging = false;
   ShortLinkCallback ? shortLinkCallback;
+  List<SingularGlobalProperty> globalProperties = [];
 
 
 
@@ -101,9 +105,18 @@ class SingularConfig {
     configMap['sessionTimeout'] = sessionTimeout;
     configMap['collectOAID'] = collectOAID;
     configMap['enableLogging'] = enableLogging;
+    List<Map<String, dynamic>> propertiesList = [];
+    for (SingularGlobalProperty prop in this.globalProperties){
+      propertiesList.add(prop.toMap);
+    }
+    configMap['globalProperties'] = propertiesList;
     return configMap;
   }
   void setShortLinkCallback(ShortLinkCallback shortLinkCallback){
     this.shortLinkCallback = shortLinkCallback;
   } 
+  void withGlobalProperty(String key, String value, bool overrideExisting){
+    this.globalProperties.add(new SingularGlobalProperty(key, value, overrideExisting));
+
+  }
 }

--- a/lib/singular_global_property.dart
+++ b/lib/singular_global_property.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/services.dart';
+
+class SingularGlobalProperty {
+
+  String _key = "";
+  String _value = "";
+  bool _overrideExisting = false;
+  
+  SingularGlobalProperty(this._key, this._value, this._overrideExisting) {
+
+  }
+
+  Map<String, dynamic> get toMap {
+    Map<String, dynamic> propertyMap = {
+      'key': _key,
+      'value': _value,
+      'overrideExisting': _overrideExisting
+    };
+
+    return propertyMap;
+  }
+}


### PR DESCRIPTION
## Title and description

Add the ability to set global properties from config


## Type of change

Check the relevant option:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API changes (requires wrappers implementation)
- [ ] This change requires a documentation update




## Details

https://singularlabs.atlassian.net/browse/SDKDEV-94
Currently there's only an option to add global properties, after init by calling singular.setGlobalProperty,
this PR adds the ability to pass global properties in config object so that they are set before session




## How Has This Been Tested?

The feature was tested by calling getGlobalProperties after initializing with properties in config object, and
verifying that the expected properties are there.

Tested both ios and android



## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - if relevant
- [x] I have added tests that cover new code or fix
- [x] Existing unit tests pass locally with my changes
- [x] Relevant code added to testing app - if relevant


