### PR TITLE
Update Docs for ios error when compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,13 @@ override func application(_ application: UIApplication, didFinishLaunchingWithOp
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
 }
     
-override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-    if let singularAppDelegate = SingularAppDelegate.shared() {
-        singularAppDelegate.continueUserActivity(userActivity, restorationHandler: nil)
+override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+        if let singularAppDelegate = SingularAppDelegate.shared() {
+            singularAppDelegate.continueUserActivity(userActivity, restorationHandler:nil)
+        }
+        return super.application(application, continue:userActivity,
+                                 restorationHandler: restorationHandler);
     }
-   return true
-}
     
 override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
     if let singularAppDelegate = SingularAppDelegate.shared() {


### PR DESCRIPTION
This fix the error in ios when compiling:

"method does not override any method from its superclass"

Also fix that singular links work when the app is already open.

This also should be updated in the [SDK Flutter documentation](https://support.singular.net/hc/en-us/articles/4408894547227-Singular-SDK-Integration-for-Flutter#Implementing_Deep_Links) in the webpage in the swift section.